### PR TITLE
Add light grey and dark grey ThemeColors 

### DIFF
--- a/library/src/main/java/org/polaric/colorful/ColorPickerPreference.java
+++ b/library/src/main/java/org/polaric/colorful/ColorPickerPreference.java
@@ -1,6 +1,7 @@
 package org.polaric.colorful;
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceViewHolder;
 import android.util.AttributeSet;
@@ -33,7 +34,7 @@ public class ColorPickerPreference extends Preference implements ColorPickerDial
                     .accentColor(color)
                     .apply();
         }
-        if (getOnPreferenceChangeListener()!=null) {
+        if (getOnPreferenceChangeListener() != null) {
             getOnPreferenceChangeListener().onPreferenceChange(this, color);
         }
     }
@@ -42,9 +43,9 @@ public class ColorPickerPreference extends Preference implements ColorPickerDial
     public void onBindViewHolder(PreferenceViewHolder holder) {
         super.onBindViewHolder(holder);
         if (primary) {
-            ((CircularView) holder.findViewById(R.id.color_indicator)).setColor(getContext().getResources().getColor(Colorful.getThemeDelegate().getPrimaryColor().getColorRes()));
+            ((CircularView) holder.findViewById(R.id.color_indicator)).setColor(ContextCompat.getColor(getContext(), Colorful.getThemeDelegate().getPrimaryColor().getColorRes()));
         } else if (accent) {
-            ((CircularView) holder.findViewById(R.id.color_indicator)).setColor(getContext().getResources().getColor(Colorful.getThemeDelegate().getAccentColor().getColorRes()));
+            ((CircularView) holder.findViewById(R.id.color_indicator)).setColor(ContextCompat.getColor(getContext(), Colorful.getThemeDelegate().getAccentColor().getColorRes()));
         }
     }
 

--- a/library/src/main/java/org/polaric/colorful/Colorful.java
+++ b/library/src/main/java/org/polaric/colorful/Colorful.java
@@ -94,7 +94,9 @@ public class Colorful {
         GREY(R.color.md_grey_500, R.color.md_grey_700),
         BLUE_GREY(R.color.md_blue_grey_500, R.color.md_blue_grey_700),
         WHITE(R.color.md_white_1000, R.color.md_white_1000),
-        BLACK(R.color.md_black_1000, R.color.md_black_1000);
+        BLACK(R.color.md_black_1000, R.color.md_black_1000),
+        LIGHT_GREY(R.color.md_grey_100, R.color.md_grey_300),
+        DARK_GREY(R.color.md_grey_900, R.color.md_black_1000);
 
         @ColorRes private int colorRes;
         @ColorRes private int darkColorRes;

--- a/library/src/main/java/org/polaric/colorful/ThemeDelegate.java
+++ b/library/src/main/java/org/polaric/colorful/ThemeDelegate.java
@@ -2,6 +2,7 @@ package org.polaric.colorful;
 
 import android.content.Context;
 import android.support.annotation.StyleRes;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 
 public class ThemeDelegate {
@@ -14,15 +15,15 @@ public class ThemeDelegate {
     @StyleRes private int styleResBase;
 
     ThemeDelegate(Context context, Colorful.ThemeColor primary, Colorful.ThemeColor accent, boolean translucent, boolean dark) {
-        this.primaryColor=primary;
-        this.accentColor=accent;
-        this.translucent=translucent;
-        this.dark=dark;
+        this.primaryColor = primary;
+        this.accentColor = accent;
+        this.translucent = translucent;
+        this.dark = dark;
         long curTime = System.currentTimeMillis();
         styleResPrimary = context.getResources().getIdentifier("primary" + primary.ordinal(), "style", context.getPackageName());
         styleResAccent = context.getResources().getIdentifier("accent" + accent.ordinal(), "style", context.getPackageName());
         styleResBase = dark ? R.style.Colorful_Dark : R.style.Colorful_Light;
-        Log.d(Util.LOG_TAG, "ThemeDelegate fetched theme in " + (System.currentTimeMillis()-curTime) + " milliseconds");
+        Log.d(Util.LOG_TAG, "ThemeDelegate fetched theme in " + (System.currentTimeMillis() - curTime) + " milliseconds");
     }
 
     @StyleRes public int getStyleResPrimary() {

--- a/library/src/main/java/org/polaric/colorful/ThemeDelegate.java
+++ b/library/src/main/java/org/polaric/colorful/ThemeDelegate.java
@@ -2,7 +2,6 @@ package org.polaric.colorful;
 
 import android.content.Context;
 import android.support.annotation.StyleRes;
-import android.support.v4.content.ContextCompat;
 import android.util.Log;
 
 public class ThemeDelegate {

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -197,4 +197,21 @@
         <item name="colorAccent">@color/md_black_1000</item>
     </style>
 
+    <style name="primary21">
+        <item name="colorPrimary">@color/md_grey_100</item>
+        <item name="colorPrimaryDark">@color/md_grey_300</item>
+    </style>
+
+    <style name="accent21">
+        <item name="colorAccent">@color/md_grey_100</item>
+    </style>
+
+    <style name="primary22">
+        <item name="colorPrimary">@color/md_grey_900</item>
+        <item name="colorPrimaryDark">@color/md_black_1000</item>
+    </style>
+
+    <style name="accent22">
+        <item name="colorAccent">@color/md_grey_900</item>
+    </style>
 </resources>


### PR DESCRIPTION
I added these two ThemeColors(for Light and Dark themes) since only black and grey are available in the color picker.
The two colors are from the bottom-most part of this page -> https://material.io/guidelines/style/color.html#color-themes

Also, the context.getResources().getColor() method has been deprecated, so it has been replaced with ContextCompat.getColor().

Please review and consider.