### PR TITLE
Support for custom theme extensions added

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Colorful().edit()
 
 ### Custom styles
 
-Colorful allows you to define custom themes (e.g. red primary color with yellow accents). If you want to use custom styles you have to do following 3 things:
+Colorful allows you to define custom themes (e.g. light red primary color with dark yellow accents). If you want to use custom styles you have to do following 3 things:
 
 1. create styles for your custom themes:
 
@@ -170,8 +170,8 @@ Colorful allows you to define custom themes (e.g. red primary color with yellow 
 	<item name="colorPrimaryDark">@color/md_red_400</item>
 </style>
 <style name="my_custom_accent_color">
-	<item name="android:colorAccent">@color/md_yellow_500</item>
-	<item name="colorAccent">@color/md_yellow_500</item>
+	<item name="android:colorAccent">@color/md_yellow_700</item>
+	<item name="colorAccent">@color/md_yellow_700</item>
 </style>
 ```
  
@@ -190,8 +190,8 @@ var myCustomColor2 = CustomThemeColor(
 	context,
 	R.style.my_custom_accent_color,
 	R.style.my_custom_accent_color,
-	R.color.md_yellow_500, // <= use the color you defined in my_custom_accent_color
-	R.color.md_yellow_500 // <= use the color you defined in my_custom_accent_color
+	R.color.md_yellow_700, // <= use the color you defined in my_custom_accent_color
+	R.color.md_yellow_700 // <= use the color you defined in my_custom_accent_color
 )
 ```
   

--- a/README.md
+++ b/README.md
@@ -153,3 +153,56 @@ Colorful().edit()
                 .apply(this)
  ```
  The `setCustomThemeOverride` method will allow Colorful to mix a provided theme with it's own. If you wish to set specific theme items yourself, such as coloring all text orange, you can do this within a style file and then have Colorful merge it with it's own theme.
+
+### Custom styles
+
+Colorful allows you to define custom themes (e.g. red primary color with yellow accents). If you want to use custom styles you have to do following 3 things:
+
+1. create styles for your custom themes:
+
+```kotlin
+<style name="my_custom_primary_color">
+	<item name="android:colorPrimary">@color/md_red_200</item>
+	<item name="colorPrimary">@color/md_red_200</item>
+</style>
+<style name="my_custom_primary_dark_color">
+	<item name="android:colorPrimaryDark">@color/md_red_400</item>
+	<item name="colorPrimaryDark">@color/md_red_400</item>
+</style>
+<style name="my_custom_accent_color">
+	<item name="android:colorAccent">@color/md_yellow_500</item>
+	<item name="colorAccent">@color/md_yellow_500</item>
+</style>
+```
+ 
+ 2. Create a custom theme color object, like following:
+ 
+```kotlin
+var myCustomColor1 = CustomThemeColor(
+	context,
+	R.style.my_custom_primary_color,
+	R.style.my_custom_primary_dark_color,
+	R.color.md_red_200, // <= use the color you defined in my_custom_primary_color
+	R.color.md_red_400 // <= use the color you defined in my_custom_primary_dark_color
+)
+// used as accent color, dark color is irrelevant...
+var myCustomColor2 = CustomThemeColor(
+	context,
+	R.style.my_custom_accent_color,
+	R.style.my_custom_accent_color,
+	R.color.md_yellow_500, // <= use the color you defined in my_custom_accent_color
+	R.color.md_yellow_500 // <= use the color you defined in my_custom_accent_color
+)
+```
+  
+3. use this custom theme color object like you would use any `ThemeColor.<COLOR>` enum object, e.g.
+ 
+```kotlin
+var defaults = Defaults(
+	primaryColor = myCustomColor1,
+	accentColor = myCustomColor2,
+	useDarkTheme = true,
+	translucent = false,
+	customTheme = 0
+)
+```

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Colorful().edit()
  ```
  The `setCustomThemeOverride` method will allow Colorful to mix a provided theme with it's own. If you wish to set specific theme items yourself, such as coloring all text orange, you can do this within a style file and then have Colorful merge it with it's own theme.
 
-### Custom styles
+### Custom theme colors
 
 Colorful allows you to define custom themes (e.g. light red primary color with dark yellow accents). If you want to use custom styles you have to do following 3 things:
 

--- a/library/src/main/java/io/multimoon/colorful/ColorPack.kt
+++ b/library/src/main/java/io/multimoon/colorful/ColorPack.kt
@@ -1,6 +1,6 @@
 package io.multimoon.colorful
 
-class ColorPack(internal val colorLight: ColorfulColor, internal val colorDark: ColorfulColor) {
-    fun normal() = colorLight
+class ColorPack(private val colorNormal: ColorfulColor, private val colorDark: ColorfulColor) {
+    fun normal() = colorNormal
     fun dark() = colorDark
 }

--- a/library/src/main/java/io/multimoon/colorful/Colorful.kt
+++ b/library/src/main/java/io/multimoon/colorful/Colorful.kt
@@ -20,9 +20,12 @@ fun initColorful(app: Application, defaults: Defaults = Defaults(ThemeColor.INDI
     val time: Long = System.currentTimeMillis()
     val prefs = app.getSharedPreferences("io.multimoon.colorful.colorvals", Context.MODE_PRIVATE)
 
+    var primary: ThemeColorInterface = ThemeColorInterface.parse(prefs.getString(primaryThemeKey, defaults.primaryColor.themeName))
+    var accent: ThemeColorInterface = ThemeColorInterface.parse(prefs.getString(accentThemeKey, defaults.accentColor.themeName))
+
     mInstance = ColorfulDelegate(
-            ThemeColor.valueOf(prefs.getString(primaryThemeKey, defaults.primaryColor.name)),
-            ThemeColor.valueOf(prefs.getString(accentThemeKey, defaults.accentColor.name)),
+            primary,
+            accent,
             prefs.getBoolean(darkThemeKey, defaults.useDarkTheme),
             prefs.getBoolean(translucentKey, defaults.translucent),
             prefs.getInt(customThemeKey, defaults.customTheme))
@@ -30,12 +33,12 @@ fun initColorful(app: Application, defaults: Defaults = Defaults(ThemeColor.INDI
     Log.d("COLORFUL", "Colorful init in " + (System.currentTimeMillis() - time) + " milliseconds!")
 }
 
-internal fun applyEdits(context: Context, primaryColor: ThemeColor, accentColor: ThemeColor, darkTheme: Boolean, translucent: Boolean, customTheme: Int = 0) {
+internal fun applyEdits(context: Context, primaryColor: ThemeColorInterface, accentColor: ThemeColorInterface, darkTheme: Boolean, translucent: Boolean, customTheme: Int = 0) {
     val prefs = context.getSharedPreferences("io.multimoon.colorful.colorvals", Context.MODE_PRIVATE)
     prefs.edit()
             .putBoolean(darkThemeKey, darkTheme)
-            .putString(primaryThemeKey, primaryColor.name)
-            .putString(accentThemeKey, accentColor.name)
+            .putString(primaryThemeKey, primaryColor.themeName)
+            .putString(accentThemeKey, accentColor.themeName)
             .putBoolean(translucentKey, translucent)
             .apply()
     if (customTheme != 0)

--- a/library/src/main/java/io/multimoon/colorful/Colorful.kt
+++ b/library/src/main/java/io/multimoon/colorful/Colorful.kt
@@ -18,7 +18,7 @@ fun Colorful(): ColorfulDelegate {
 
 fun initColorful(app: Application, defaults: Defaults = Defaults(ThemeColor.INDIGO, ThemeColor.RED, true, true)) {
     val time: Long = System.currentTimeMillis()
-    val prefs = app.getSharedPreferences("io.multimoon.colorful.colorvals", Context.MODE_PRIVATE)
+    val prefs = app.getSharedPreferences(ThemeEditor.PREF_NAME, Context.MODE_PRIVATE)
 
     var primary: ThemeColorInterface = ThemeColorInterface.parse(prefs.getString(primaryThemeKey, defaults.primaryColor.themeName))
     var accent: ThemeColorInterface = ThemeColorInterface.parse(prefs.getString(accentThemeKey, defaults.accentColor.themeName))
@@ -31,23 +31,4 @@ fun initColorful(app: Application, defaults: Defaults = Defaults(ThemeColor.INDI
             prefs.getInt(customThemeKey, defaults.customTheme))
 
     Log.d("COLORFUL", "Colorful init in " + (System.currentTimeMillis() - time) + " milliseconds!")
-}
-
-internal fun applyEdits(context: Context, primaryColor: ThemeColorInterface, accentColor: ThemeColorInterface, darkTheme: Boolean, translucent: Boolean, customTheme: Int = 0) {
-    val prefs = context.getSharedPreferences("io.multimoon.colorful.colorvals", Context.MODE_PRIVATE)
-    prefs.edit()
-            .putBoolean(darkThemeKey, darkTheme)
-            .putString(primaryThemeKey, primaryColor.themeName)
-            .putString(accentThemeKey, accentColor.themeName)
-            .putBoolean(translucentKey, translucent)
-            .apply()
-    if (customTheme != 0)
-        prefs.edit().putInt(customThemeKey, customTheme).apply()
-    else
-        prefs.edit().remove(customThemeKey).apply()
-    mInstance = ColorfulDelegate(primaryColor, accentColor, darkTheme, translucent)
-}
-
-internal fun resetPrefs(context: Context) {
-    context.getSharedPreferences("io.multimoon.colorful.colorvals", Context.MODE_PRIVATE).edit().clear().apply()
 }

--- a/library/src/main/java/io/multimoon/colorful/ColorfulColor.kt
+++ b/library/src/main/java/io/multimoon/colorful/ColorfulColor.kt
@@ -1,8 +1,18 @@
 package io.multimoon.colorful
 
+import android.content.Context
 import android.graphics.Color
+import android.support.annotation.ColorRes
+import android.support.v4.content.ContextCompat
 
-class ColorfulColor(internal val hexColor:String) {
+class ColorfulColor(private val hexColor: String) {
+
+    constructor(context: Context, @ColorRes colorRes: Int) : this("#${Integer.toHexString(ContextCompat.getColor(context, colorRes))}")
+
+    private val int: Int by lazy {
+        Color.parseColor(hexColor)
+    }
+
+    fun asInt() = int
     fun asHex() = hexColor
-    fun asInt() = Color.parseColor(hexColor)
 }

--- a/library/src/main/java/io/multimoon/colorful/ColorfulDelegate.kt
+++ b/library/src/main/java/io/multimoon/colorful/ColorfulDelegate.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.support.annotation.StyleRes
 import android.util.Log
 
-class ColorfulDelegate(private var primaryColor: ThemeColor, private var accentColor: ThemeColor, private var darkTheme: Boolean, private var translucent: Boolean, private @StyleRes val customTheme: Int = 0) {
+class ColorfulDelegate(private var primaryColor: ThemeColorInterface, private var accentColor: ThemeColorInterface, private var darkTheme: Boolean, private var translucent: Boolean, private @StyleRes val customTheme: Int = 0) {
 
     fun apply(activity: Activity, override: Boolean = true, appcompat: Boolean = false) {
         if (appcompat) {
@@ -22,9 +22,9 @@ class ColorfulDelegate(private var primaryColor: ThemeColor, private var accentC
         }
     }
 
-    fun getPrimaryColor(): ThemeColor = primaryColor
+    fun getPrimaryColor(): ThemeColorInterface = primaryColor
 
-    fun getAccentColor(): ThemeColor = accentColor
+    fun getAccentColor(): ThemeColorInterface = accentColor
 
     fun getDarkTheme(): Boolean = darkTheme
 
@@ -41,7 +41,7 @@ class ColorfulDelegate(private var primaryColor: ThemeColor, private var accentC
     }
 
     internal fun getThemeString(): String {
-        return primaryColor.name + ":" + accentColor.name + ":" + darkTheme + ":" + customTheme + ":" + translucent
+        return primaryColor.themeName + ":" + accentColor.themeName + ":" + darkTheme + ":" + customTheme + ":" + translucent
     }
 
 }

--- a/library/src/main/java/io/multimoon/colorful/ColorfulDelegate.kt
+++ b/library/src/main/java/io/multimoon/colorful/ColorfulDelegate.kt
@@ -37,7 +37,7 @@ class ColorfulDelegate(private var primaryColor: ThemeColorInterface, private va
     }
 
     fun clear(context: Context) {
-        resetPrefs(context)
+        edit().resetPrefs(context)
     }
 
     internal fun getThemeString(): String {

--- a/library/src/main/java/io/multimoon/colorful/Defaults.kt
+++ b/library/src/main/java/io/multimoon/colorful/Defaults.kt
@@ -2,4 +2,4 @@ package io.multimoon.colorful
 
 import android.support.annotation.StyleRes
 
-data class Defaults(val primaryColor: ThemeColor, val accentColor: ThemeColor, val useDarkTheme: Boolean, val translucent: Boolean, @StyleRes val customTheme: Int = 0)
+data class Defaults(val primaryColor: ThemeColorInterface, val accentColor: ThemeColorInterface, val useDarkTheme: Boolean, val translucent: Boolean, @StyleRes val customTheme: Int = 0)

--- a/library/src/main/java/io/multimoon/colorful/ThemeColor.kt
+++ b/library/src/main/java/io/multimoon/colorful/ThemeColor.kt
@@ -1,8 +1,62 @@
 package io.multimoon.colorful
 
+import android.content.Context
+import android.support.annotation.ColorRes
 import android.support.annotation.StyleRes
 
-enum class ThemeColor(private val primaryRes: Int, private val accentRes: Int, private val color: ColorPack) {
+interface ThemeColorInterface {
+
+    companion object {
+        fun parse(data: String): ThemeColorInterface {
+            var color: ThemeColorInterface
+            if (data.contains("|")) {
+                var nameParts = data.split("|")
+                if (nameParts.size != 4)
+                    return ThemeColor.GREEN
+                color = CustomThemeColor(nameParts[0].toInt(), nameParts[1].toInt(), nameParts[2], nameParts[3])
+            } else {
+                color = ThemeColor.valueOf(data)
+            }
+            return color
+        }
+
+        fun toString(themeColorInterface: ThemeColorInterface): String {
+            if (themeColorInterface is ThemeColor)
+                return themeColorInterface.name
+            else
+                return "${themeColorInterface.primaryStyle()}|${themeColorInterface.accentStyle()}|${themeColorInterface.getColorPack().normal().asHex()}|${themeColorInterface.getColorPack().dark().asHex()}"
+        }
+    }
+
+    @StyleRes
+    fun primaryStyle(): Int
+
+    @StyleRes
+    fun accentStyle(): Int
+
+    fun getColorPack(): ColorPack
+
+    val themeName: String
+}
+
+class CustomThemeColor(private val primaryRes: Int, private val accentRes: Int, private val color: ColorPack) : ThemeColorInterface {
+
+    constructor(primaryRes: Int, accentRes: Int, colorNormalHex: String, colorDarkHex: String) : this(primaryRes, accentRes, ColorPack(ColorfulColor(colorNormalHex), ColorfulColor(colorDarkHex)))
+
+    constructor(context: Context, primaryRes: Int, accentRes: Int, @ColorRes colorNormalRes: Int, @ColorRes colorDarkRes: Int) : this(primaryRes, accentRes, ColorPack(ColorfulColor(context, colorNormalRes), ColorfulColor(context, colorDarkRes)))
+
+    @StyleRes
+    override fun primaryStyle() = primaryRes
+
+    @StyleRes
+    override fun accentStyle() = accentRes
+
+    override fun getColorPack() = color
+
+    override val themeName: String = ThemeColorInterface.toString(this)
+}
+
+enum class ThemeColor(private val primaryRes: Int, private val accentRes: Int, private val color: ColorPack) : ThemeColorInterface {
     RED(R.style.primary0, R.style.accent0, ColorPack(ColorfulColor("#f44336"), ColorfulColor("#d32f2f"))),
     PINK(R.style.primary1, R.style.accent1, ColorPack(ColorfulColor("#e91e63"), ColorfulColor("#c2185b"))),
     PURPLE(R.style.primary2, R.style.accent2, ColorPack(ColorfulColor("#9c27b0"), ColorfulColor("#7b1fa2"))),
@@ -26,11 +80,13 @@ enum class ThemeColor(private val primaryRes: Int, private val accentRes: Int, p
     BLACK(R.style.primary20, R.style.accent20, ColorPack(ColorfulColor("#000000"), ColorfulColor("#000000")));
 
     @StyleRes
-    fun primaryStyle() = primaryRes
+    override fun primaryStyle() = primaryRes
 
     @StyleRes
-    fun accentStyle() = accentRes
+    override fun accentStyle() = accentRes
 
-    fun getColorPack() = color
+    override fun getColorPack() = color
+
+    override val themeName: String = ThemeColorInterface.toString(this)
 }
 

--- a/library/src/main/java/io/multimoon/colorful/ThemeEditor.kt
+++ b/library/src/main/java/io/multimoon/colorful/ThemeEditor.kt
@@ -6,6 +6,10 @@ import android.util.Log
 
 class ThemeEditor(internal var primaryColor: ThemeColorInterface = ThemeColor.INDIGO, internal var accentColor: ThemeColorInterface = ThemeColor.RED, internal var darkTheme: Boolean = true, internal var translucent: Boolean, internal @StyleRes var customTheme: Int = 0) {
 
+    companion object {
+        val PREF_NAME: String = "io.multimoon.colorful.colorvals"
+    }
+
     fun setPrimaryColor(primaryColor: ThemeColorInterface): ThemeEditor {
         this.primaryColor = primaryColor
         return this
@@ -34,5 +38,24 @@ class ThemeEditor(internal var primaryColor: ThemeColorInterface = ThemeColor.IN
     fun apply(context: Context, callback: () -> Unit = { Log.d("Colorful", "Callback omitted") }) {
         applyEdits(context, primaryColor, accentColor, darkTheme, translucent, customTheme)
         callback()
+    }
+
+    private fun applyEdits(context: Context, primaryColor: ThemeColorInterface, accentColor: ThemeColorInterface, darkTheme: Boolean, translucent: Boolean, customTheme: Int = 0) {
+        val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        prefs.edit()
+                .putBoolean(darkThemeKey, darkTheme)
+                .putString(primaryThemeKey, primaryColor.themeName)
+                .putString(accentThemeKey, accentColor.themeName)
+                .putBoolean(translucentKey, translucent)
+                .apply()
+        if (customTheme != 0)
+            prefs.edit().putInt(customThemeKey, customTheme).apply()
+        else
+            prefs.edit().remove(customThemeKey).apply()
+        mInstance = ColorfulDelegate(primaryColor, accentColor, darkTheme, translucent)
+    }
+
+    fun resetPrefs(context: Context) {
+        context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE).edit().clear().apply()
     }
 }

--- a/library/src/main/java/io/multimoon/colorful/ThemeEditor.kt
+++ b/library/src/main/java/io/multimoon/colorful/ThemeEditor.kt
@@ -4,14 +4,14 @@ import android.content.Context
 import android.support.annotation.StyleRes
 import android.util.Log
 
-class ThemeEditor(internal var primaryColor: ThemeColor = ThemeColor.INDIGO, internal var accentColor: ThemeColor = ThemeColor.RED, internal var darkTheme: Boolean = true, internal var translucent: Boolean, internal @StyleRes var customTheme: Int = 0) {
+class ThemeEditor(internal var primaryColor: ThemeColorInterface = ThemeColor.INDIGO, internal var accentColor: ThemeColorInterface = ThemeColor.RED, internal var darkTheme: Boolean = true, internal var translucent: Boolean, internal @StyleRes var customTheme: Int = 0) {
 
-    fun setPrimaryColor(primaryColor: ThemeColor): ThemeEditor {
+    fun setPrimaryColor(primaryColor: ThemeColorInterface): ThemeEditor {
         this.primaryColor = primaryColor
         return this
     }
 
-    fun setAccentColor(accentColor: ThemeColor): ThemeEditor {
+    fun setAccentColor(accentColor: ThemeColorInterface): ThemeEditor {
         this.accentColor = accentColor
         return this
     }


### PR DESCRIPTION
**Done**

* Added support for custom theme extensions
* `ColorfulColor` optimised
* `ColorPack` fields made private
* moved 2 editor functions from `ColorfulDelegate` to `ThemeEditor` as this makes more sense imho
* defined a constant in `ThemeEditor` for the preference file name

**How it works**

`ThemeColor` is replaced by `ThemeColorInterface` in the whole library. 

1) Create styles for the custom theme like following:

		<style name="primary_red_50">
			<item name="android:colorPrimary">@color/md_red_50</item>
			<item name="colorPrimary">@color/md_red_50</item>
		</style>

		<style name="primary_dark_red_50">
			<item name="android:colorPrimaryDark">@color/md_red_50</item>
			<item name="colorPrimaryDark">@color/md_red_50</item>
		</style>

		<style name="accent_red_50">
			<item name="android:colorAccent">@color/md_red_50</item>
			<item name="colorAccent">@color/md_red_50</item>
		</style>
	
2) Create a `CustomThemeColor` object like following (or use one of the alternative constructors):

        var primaryColor = CustomThemeColor(
                context,
                R.style.primary_red_50,
                R.style.accent_red_50,
                R.color.md_red_50,
                R.color.md_red_50
        )
		
3) simply use this `primaryColor` object like you used e.g. `ThemeColor.RED` before
		
*What do you think about this? Do you consider this feature useful as well?*